### PR TITLE
Pinger makes undesired request to /

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/*
+*.swp

--- a/pool_pinger.js
+++ b/pool_pinger.js
@@ -39,6 +39,10 @@ PoolPinger.prototype.ping = function () {
 PoolPinger.prototype.make_request = function () {
     var self = this;
 
+    if (! this.pool_endpoint.ping_path) {
+        return;
+    }
+
     this.req_timer = setTimeout(function () {
         self.on_timeout();
     }, this.ping_timeout);


### PR DESCRIPTION
There's a tricky edge case here when `remove_endpoint()` is invoked on the pool while a soon-to-error-out pinger request is in-flight. Removing an endpoint from the pool `close()`s the `PoolEndpoint` and nulls out the `ping_path`. However, in that time, a pinger could have been started. If the pingers request were to error out it'll cause a subsequent `ping()` within the pinger to the root ("/") endpoint of your HTTP server. Most of the time this likely goes unnoticed in production environments.

It took a bit of weasling to reproduce in a test case, but if you take the check that I added out of the `make_request()` function, the assertion will fail.