### PR TITLE
Emit response event and provide req_set as an arg

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -180,6 +180,7 @@ Pool.prototype.request = function (options, data, callback) {
             options.reused = false;
         }
         self.emit("timing", req_set.duration, options);
+        self.emit("response", err, req_set);
         callback(err, res, body);
     });
     return req_set.do_request();

--- a/pool.js
+++ b/pool.js
@@ -180,7 +180,7 @@ Pool.prototype.request = function (options, data, callback) {
             options.reused = false;
         }
         self.emit("timing", req_set.duration, options);
-        self.emit("response", err, req_set);
+        self.emit("response", err, req_set, res);
         callback(err, res, body);
     });
     return req_set.do_request();

--- a/test/pool_test.js
+++ b/test/pool_test.js
@@ -232,6 +232,44 @@ describe("Pool", function () {
                 assert.equal(body, success_body);
             });
         });
+
+        it("causes pool to emit response event", function (done) {
+            var doneCounter = 0;
+            var pool = new Pool(http, ["127.0.0.1:8080", "127.0.0.1:8081", "127.0.0.1:8082"]);
+
+            function doneOne() {
+                if (++doneCounter === 2) {
+                    done();
+                }
+            }
+
+            function assertResponse(assertions) {
+                pool.once("response", function (err, poolReq) {
+                    assertions(err, poolReq);
+                    assert.ok(poolReq);
+                    assert.equal(poolReq.options.path, "/foo");
+                    doneOne();
+                });
+            }
+
+            function requestFoo() {
+                pool.request("/foo", function() {});
+            }
+
+            // Without error
+            FakeEndpointRequest.prototype.start = start_with_success;
+            assertResponse(function(err) {
+                assert.ifError(err);
+            });
+            requestFoo();
+
+            // With error
+            FakeEndpointRequest.prototype.start = start_with_fail;
+            assertResponse(function(err) {
+                assert.ok(err);
+            });
+            requestFoo();
+        });
     });
 
     describe("get()", function () {

--- a/test/pool_test.js
+++ b/test/pool_test.js
@@ -244,8 +244,8 @@ describe("Pool", function () {
             }
 
             function assertResponse(assertions) {
-                pool.once("response", function (err, poolReq) {
-                    assertions(err, poolReq);
+                pool.once("response", function (err, poolReq, res) {
+                    assertions(err, poolReq, res);
                     assert.ok(poolReq);
                     assert.equal(poolReq.options.path, "/foo");
                     doneOne();
@@ -258,15 +258,17 @@ describe("Pool", function () {
 
             // Without error
             FakeEndpointRequest.prototype.start = start_with_success;
-            assertResponse(function(err) {
+            assertResponse(function(err, poolReq, res) {
                 assert.ifError(err);
+                assert.ok(res);
             });
             requestFoo();
 
             // With error
             FakeEndpointRequest.prototype.start = start_with_fail;
-            assertResponse(function(err) {
+            assertResponse(function(err, poolReq, res) {
                 assert.ok(err);
+                assert.equal(res, undefined);
             });
             requestFoo();
         });


### PR DESCRIPTION
It'd be nice to be able to have access to and track the number of attempts, aborts, hangups on a per request basis as a listener of the pool.