### PR TITLE
call destroy on the KeepAliveAgent on closing the pool

### DIFF
--- a/pool_endpoint.js
+++ b/pool_endpoint.js
@@ -81,6 +81,10 @@ PoolEndpoint.prototype.close = function () {
         this.requests[req_id].on_aborted();
         this.delete_request(req_id);
     }
+
+    if (this.agent && typeof(this.agent.destroy) === 'function') {
+        this.agent.destroy();
+    }
 };
 
 // options: {
@@ -219,11 +223,11 @@ PoolEndpoint.prototype.set_healthy = function (new_state) {
 PoolEndpoint.prototype.setHealthy = PoolEndpoint.prototype.set_healthy;
 
 PoolEndpoint.prototype.delete_request = function (id) {
-	delete this.requests[id];
+    delete this.requests[id];
 };
 
 module.exports = function init(new_global) {
     GO = new_global;
 
-	return PoolEndpoint;
+    return PoolEndpoint;
 };

--- a/test/pool_test.js
+++ b/test/pool_test.js
@@ -341,4 +341,12 @@ describe("Pool", function () {
             });
         });
     });
+
+    describe("close()", function () {
+        it("does not fail", function (done) {
+            var pool = new Pool(http, ["127.0.0.1:8080", "127.0.0.1:8081"]);
+            pool.close();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Our node program (e.g., test scripts) won't exit due to lb_pool not unref'ing sockets. This change fixes that.