### PR TITLE
differentiate timeout errors from hangups/aborts

### DIFF
--- a/pool_endpoint.js
+++ b/pool_endpoint.js
@@ -142,6 +142,7 @@ PoolEndpoint.prototype.stats = function () {
         failures: this.failures,
         filtered: this.filtered,
         healthy: this.healthy,
+        socket_count: this.agent.sockets[this.name] ? this.agent.sockets[this.name].length : 0,
         socket_request_counts: request_counts
     };
 };

--- a/test/endpoint_test.js
+++ b/test/endpoint_test.js
@@ -80,7 +80,7 @@ describe("PoolEndpoint", function () {
                 var error;
                 e.request({path: "/foo", method: "GET"}, function (err, response, body) {
                     error = err;
-                    assert.strictEqual(error.reason, "socket hang up");
+                    assert.strictEqual(error.reason, "timed_out");
                     assert.strictEqual(/request timed out$/.test(error.message), true);
                     assert.strictEqual(response, undefined);
                     assert.strictEqual(body, undefined);
@@ -118,7 +118,7 @@ describe("PoolEndpoint", function () {
 
                 setTimeout(function () {
                     s.close();
-                    assert.equal(error.reason, "aborted");
+                    assert.equal(error.reason, "timed_out");
                     assert.equal(/response timed out$/.test(error.message), true);
                     done();
                 }, 60);
@@ -192,7 +192,8 @@ describe("PoolEndpoint", function () {
 
                 setTimeout(function () {
                     s.close();
-                    assert.equal(error.reason, "socket hang up");
+                    assert.equal(error.reason, "timed_out");
+                    assert.equal(/request timed out$/.test(error.message), true);
                     assert.equal(Object.keys(e.requests).length, 0);
                     done();
                 }, 50);

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+FILES=$BASEDIR/*_test.js
+for f in $FILES
+do
+  echo "====== Running $f..."
+  ./node_modules/.bin/mocha $f
+  sleep 3
+done


### PR DESCRIPTION
This allows us to configure retries on timeouts differently than hangups/aborts

@mranney Can you take a look?